### PR TITLE
Run build only when pom.xml exists.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
         if: contains(matrix.os, 'win') == false
         run: chmod +x ./mvnw
       - name: Build with Maven
+        if: hashFiles('pom.xml') != ''
         run: ./mvnw -DRunningOnCi=true package --file pom.xml --batch-mode
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn


### PR DESCRIPTION
We cannot move this check on a job level, as we need to check out the repository to run the check.